### PR TITLE
Add controlled notifications to notification system

### DIFF
--- a/application/qml.qrc
+++ b/application/qml.qrc
@@ -25,6 +25,7 @@
         <file alias="NotificationsSystem.qml">qml/NotificationsSystem.qml</file>
         <file alias="NotificationPopSticky.qml">qml/NotificationPopSticky.qml</file>
         <file alias="NotificationPopTransient.qml">qml/NotificationPopTransient.qml</file>
+        <file alias="NotificationPopControlled.qml">qml/NotificationPopControlled.qml</file>
         <file alias="Keyboard.qml">qml/Keyboard.qml</file>
         <file alias="KdeConnect.qml">qml/KdeConnect.qml</file>
         <file alias="SplashScreen.qml">qml/SplashScreen.qml</file>

--- a/application/qml/NotificationPopControlled.qml
+++ b/application/qml/NotificationPopControlled.qml
@@ -1,0 +1,128 @@
+import QtQuick.Layouts 1.4
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import org.kde.kirigami 2.4 as Kirigami
+import QtGraphicalEffects 1.0
+import Mycroft 1.0 as Mycroft
+
+Rectangle {
+    id: popbox
+    color: "#313131"
+    radius: Mycroft.Units.gridUnit / 2
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.leftMargin: Kirigami.Units.largeSpacing
+    anchors.rightMargin: Kirigami.Units.largeSpacing
+    border.width: Mycroft.Units.smallSpacing
+    border.color: styleAreaNotifier.color
+    height: Mycroft.Units.gridUnit * 4
+    property var currentNotification
+    property string notifstyle: currentNotification.style
+
+    Rectangle {
+        id: styleAreaNotifier
+        color: switch(popbox.notifstyle) {
+            case "info":
+                return "#3498db"
+            case "warning":
+                return "#cf850f"
+            case "success":
+                return "#00bc8c"
+            case "error":
+                return "#e74c3c"
+            default:
+                return "#3498db"
+        }
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        height: Mycroft.Units.gridUnit * 3
+        width: Mycroft.Units.gridUnit * 3
+        radius: parent.radius / 2
+        layer.enabled: true
+        layer.effect: DropShadow {
+            transparentBorder: true
+            horizontalOffset: 3
+            samples: 16
+            verticalOffset: 0
+            spread: 0.3
+            color: Qt.rgba(0, 0, 0, 0.4)
+        }
+
+        Kirigami.Icon {
+            anchors.fill: parent
+            anchors.margins: Mycroft.Units.smallSpacing
+            source: switch(popbox.notifstyle) {
+                case "info":
+                    return "documentinfo"
+                case "warning":
+                    return "data-warning"
+                case "success":
+                    return "emblem-success"
+                case "error":
+                    return "emblem-error"
+                default:
+                    return "documentinfo"
+            }
+            color: "white"
+        }
+    }
+
+    RowLayout {
+        id: notificationRowBoxLayout
+        anchors.left: styleAreaNotifier.right
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        anchors.margins: Mycroft.Units.largeSpacing
+
+        Label {
+            id: notificationContent
+            text: currentNotification.text
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.bottomMargin: Mycroft.Units.smallSpacing
+            wrapMode: Text.WordWrap
+            verticalAlignment: Text.AlignVCenter
+            font.pixelSize: parent.width * 0.045
+            fontSizeMode: Text.Fit
+            minimumPixelSize: 14
+            maximumLineCount: 2
+            elide: Text.ElideRight
+            color: "#ffffff"
+        }
+
+        Kirigami.Separator {
+            Layout.preferredWidth: Kirigami.Units.smallSpacing * 0.25
+            Layout.fillHeight: true
+            color: "#8F8F8F"
+        }
+
+        Item {
+            Layout.preferredWidth: Mycroft.Units.gridUnit * 4
+            Layout.fillHeight: true
+
+            AbstractButton {
+                width: parent.width - Kirigami.Units.largeSpacing * 2
+                height: width
+                anchors.centerIn: parent
+
+                background: Rectangle {
+                    color: "transparent"
+                }
+
+                contentItem: Item {
+                    Kirigami.Icon {
+                    anchors.centerIn: parent
+                    width: Mycroft.Units.iconSizes.medium
+                    height: Mycroft.Units.iconSizes.medium
+                    source: Qt.resolvedUrl("icons/close.svg")
+                    }
+                }
+
+                onClicked: {
+                    popbox.destroy()
+                }
+            }
+        }
+    }
+}

--- a/application/qml/NotificationsSystem.qml
+++ b/application/qml/NotificationsSystem.qml
@@ -16,6 +16,8 @@ Column {
     z: 999
 
     property var notificationData
+    property var controlledNotificationData
+    property var controlledNotificationObject
 
     Connections {
         target: Mycroft.MycroftController
@@ -27,6 +29,15 @@ Column {
             }
             if (type == "ovos.notification.show") {
                 display_notification()
+            }
+            if (type == "ovos.notification.controlled.type.show") {
+                var control_notif_data = data.notification
+                notificationsSys.controlledNotificationData = control_notif_data
+                console.log(JSON.stringify(control_notif_data))
+                display_update_controlled_notification()
+            }
+            if (type == "ovos.notification.controlled.type.remove") {
+                remove_controlled_notification()
             }
         }
     }
@@ -48,12 +59,34 @@ Column {
             if (component.status !== Component.Ready)
             {
                 if (component.status === Component.Error) {
-                    console.debug("Error: "+ component.errorString());
+                    console.debug("Error: " + component.errorString());
                 }
                 return;
             } else {
                 var notif_object = component.createObject(notificationsSys, {currentNotification: notificationsSys.notificationData})
             }
         }
+    }
+
+    function display_update_controlled_notification() {
+        console.log("Displaying Controlled Notification")
+        if(!notificationsSys.controlledNotificationObject){
+            var controlled_component = Qt.createComponent("NotificationPopControlled.qml");
+            if (controlled_component.status !== Component.Ready) {
+                if (controlled_component.status === Component.Error) {
+                    console.debug("Error: " + controlled_component.errorString());
+                }
+                return;
+            } else {
+                notificationsSys.controlledNotificationObject = controlled_component.createObject(notificationsSys, {currentNotification: notificationsSys.controlledNotificationData})
+            }
+        } else {
+            notificationsSys.controlledNotificationObject.currentNotification = notificationsSys.controlledNotificationData
+        }
+    }
+
+    function remove_controlled_notification() {
+        console.log("Removing Controlled Notification")
+        notificationsSys.controlledNotificationObject.destroy();
     }
 }


### PR DESCRIPTION
- Controlled notifications act as a push message system for skills and other gui interfaces
- The skill / gui interface controls how long the notification remains valid for
- The data is also allowed to by dynamically changed by skills

Examples: 

![example-notification-wip-2](https://user-images.githubusercontent.com/19663666/190639664-1118cd7d-5619-4314-a6fb-5e3b68ff90ff.gif)

![example-notification-wip-3](https://user-images.githubusercontent.com/19663666/190639704-71b74c80-269e-4aed-9321-2e5c420a8f3e.gif)
