### PR TITLE
Add initial support for OAuth process and theme edge lighting

### DIFF
--- a/application/qml.qrc
+++ b/application/qml.qrc
@@ -36,6 +36,7 @@
         <file alias="PairingArea.qml">qml/PairingArea.qml</file>
         <file alias="ShutdownOptions.qml">qml/ShutdownOptions.qml</file>
         <file alias="FactoryResetUI.qml">qml/FactoryResetUI.qml</file>
+        <file alias="OAuthLoader.qml">qml/OAuthLoader.qml</file>
         <file>icons/configure.svg</file>
         <file>icons/home.svg</file>
         <file>icons/screen-rotate.svg</file>

--- a/application/qml/ListenerAnimation.qml
+++ b/application/qml/ListenerAnimation.qml
@@ -10,7 +10,7 @@ Rectangle {
     property Gradient borderGradient: borderGradient
     property int borderWidth: Kirigami.Units.largeSpacing - Kirigami.Units.smallSpacing
     property bool horizontalMode: parent.width > parent.height ? 1 : 0
-    readonly property color primaryBorderColor: Qt.rgba(1, 0, 0, 0.9)
+    readonly property color primaryBorderColor: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.9)
     readonly property color secondaryBorderColor: Qt.rgba(1, 1, 1, 0.7)
     color: "transparent"
     visible: false

--- a/application/qml/OAuthLoader.qml
+++ b/application/qml/OAuthLoader.qml
@@ -1,0 +1,66 @@
+import QtQuick.Layouts 1.4
+import QtQuick 2.9
+import QtQuick.Controls 2.12
+import org.kde.kirigami 2.11 as Kirigami
+import QtGraphicalEffects 1.0
+import Mycroft 1.0 as Mycroft
+
+Popup {
+    id: oAuthPopup
+    width: parent.width * 0.8
+    height: parent.height * 0.8
+    x: (parent.width - width) / 2
+    y: (parent.height - height) / 2
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+    property string url: ""
+
+    function forwardAuthentication(redirectURL) {
+        Mycroft.MycroftController.sendRequest("ovos.oauth.gui.authentication.forward", {
+            "redirectURL": redirectURL
+        })
+    }
+
+    background: Rectangle {
+        color: Kirigami.Theme.backgroundColor
+        anchors.fill: parent
+    }
+
+     contentItem: Item {
+
+        Item {
+            width: rotation === 90 || rotation == -90 ? parent.height : parent.width
+            height: rotation === 90 || rotation == -90 ? parent.width : parent.height
+            anchors.centerIn: parent
+
+            rotation: {
+                switch (applicationSettings.rotation) {
+                    case "CW":
+                        return 90;
+                    case "CCW":
+                        return -90;
+                    case "UD":
+                        return 180;
+                    case "NORMAL":
+                    default:
+                        return 0;
+                }
+            }
+            
+            WebEngineView {
+                id: engineView
+                anchors.fill: parent
+                enabled: oAuthPopup.opened
+                visible: oAuthPopup.opened
+                url: oAuthPopup.url
+
+                onUrlChanged: {
+                    url_to_check = engineView.url
+                    if (url_to_check.indexOf("code") > -1 && url_to_check.indexOf("state") > -1) {
+                        oAuthPopup.forwardAuthentication(url_to_check)
+                        oAuthPopup.close()
+                    }
+                }
+            }
+        }
+     }
+}

--- a/application/qml/OAuthLoader.qml
+++ b/application/qml/OAuthLoader.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls 2.12
 import org.kde.kirigami 2.11 as Kirigami
 import QtGraphicalEffects 1.0
 import Mycroft 1.0 as Mycroft
+import QtWebEngine 1.9
 
 Popup {
     id: oAuthPopup
@@ -15,7 +16,7 @@ Popup {
     property string url: ""
 
     function forwardAuthentication(redirectURL) {
-        Mycroft.MycroftController.sendRequest("ovos.oauth.gui.authentication.forward", {
+        Mycroft.MycroftController.sendRequest("ovos.shell.oauth.authentication.forward", {
             "redirectURL": redirectURL
         })
     }

--- a/application/qml/main.qml
+++ b/application/qml/main.qml
@@ -90,6 +90,11 @@ Kirigami.AbstractApplicationWindow {
                 var script_to_run_path = data.script
                 resetOperations.runResetOperations(script_to_run_path)
             }
+            if (type == "ovos.shell.oauth.start.authentication") {
+                var url = data.url
+                oauthLoader.url = url
+                oauthLoader.open()
+            }
         }
     }
 
@@ -191,6 +196,11 @@ Kirigami.AbstractApplicationWindow {
                 margins: Kirigami.Units.largeSpacing
             }
             z: 998
+        }
+
+        OAuthLoader {
+            id: oauthLoader
+            z: 6
         }
 
         Item {


### PR DESCRIPTION
- Theme based edge lighting, uses themes main color for edge lighting

- Request Authentication Web View: 
   - bus message: "ovos.shell.oauth.start.authentication""
   - data required: "url"

- Response Redirect URL Listener:
  - bus message: "ovos.shell.oauth.authentication.forward"
  - data sent: "redirectURL"