### PR TITLE
add configuration option for transient pop notification

### DIFF
--- a/application/qml/NotificationPopTransient.qml
+++ b/application/qml/NotificationPopTransient.qml
@@ -18,6 +18,7 @@ Rectangle {
     height: Mycroft.Units.gridUnit * 4
     property var currentNotification
     property string notifstyle: currentNotification.style
+    property int notifduration: currentNotification.duration * 1000
 
     function getBoxWidth(){
         return popbox.width;
@@ -45,7 +46,7 @@ Rectangle {
                 target: timerBar
                 property: "width"
                 to: 0
-                duration: 10000
+                duration: notifduration
                 running: timerBar.visible && timerBar.width > 0 ? 1 : 0
                 onRunningChanged: {
                     timerBarAnimation.from = getBoxWidth()
@@ -56,7 +57,7 @@ Rectangle {
 
     Timer {
         id: notificationEndTimer
-        interval: 10000
+        interval: notifduration
         repeat: false
         running: parent.visible
         onTriggered: {


### PR DESCRIPTION
Adds the possibility to define a on screen duration for transient pop notifications.

Positivly tested
Going further: If duration is set to 0, the notification is shown a millisecond. Maybe we can eliminate this, too. 

Related: [PHAL-plugin](https://github.com/OpenVoiceOS/ovos-PHAL-plugin-notification-widgets/pull/4) / [ovos-utils](https://github.com/OpenVoiceOS/ovos-utils/pull/92)

