### PR TITLE
fix/VolumeOSD.qml

### DIFF
--- a/application/qml/osd/VolumeOSD.qml
+++ b/application/qml/osd/VolumeOSD.qml
@@ -32,7 +32,7 @@ SliderControl {
     }
 
     onChangeValueChanged: {
-        Mycroft.MycroftController.sendRequest("mycroft.volume.set.gui", {"percent": changeValue},
+        Mycroft.MycroftController.sendRequest("mycroft.volume.set", {"percent": changeValue},
             {"session": {"session_id": "default"}});
         feedbackTimer.restart()
     }

--- a/application/qml/osd/VolumeOSD.qml
+++ b/application/qml/osd/VolumeOSD.qml
@@ -41,7 +41,7 @@ SliderControl {
         target: Mycroft.MycroftController
 
         onIntentRecevied: {
-            if (type == "mycroft.volume.get.response") {
+            if (type == "mycroft.volume.display") {
                 root.visible = true
                 root.value = Math.round(data.percent * 100);
                 feedbackTimer.restart()

--- a/application/qml/panel/SlidingPanel.qml
+++ b/application/qml/panel/SlidingPanel.qml
@@ -39,7 +39,7 @@ Item {
 
         onMenuOpenChanged: {
             if(menuOpen) {
-                Mycroft.MycroftController.sendRequest("mycroft.volume.get.sliding.panel", {},
+                Mycroft.MycroftController.sendRequest("mycroft.volume.get", {},
                     {"session": {"session_id": "default"}})
             }
         }

--- a/application/qml/panel/quicksettings/VolumeSlider.qml
+++ b/application/qml/panel/quicksettings/VolumeSlider.qml
@@ -32,7 +32,7 @@ SliderBase {
     sliderButtonLabel: Math.round(slider.position * 100)
 
     onChangeValueChanged: {
-        Mycroft.MycroftController.sendRequest("mycroft.volume.set.gui", {"percent": (changeValue / 100)},
+        Mycroft.MycroftController.sendRequest("mycroft.volume.set", {"percent": (changeValue / 100)},
             {"session": {"session_id": "default"}});
     }
 

--- a/application/qml/panel/quicksettings/VolumeSlider.qml
+++ b/application/qml/panel/quicksettings/VolumeSlider.qml
@@ -65,10 +65,6 @@ SliderBase {
             if (type == "mycroft.volume.get.response") {
                 slider.value = Math.round(data.percent * 100);
             }
-
-            if (type == "mycroft.volume.get.sliding.panel.response") {
-                slider.value = Math.round(data.percent * 100);
-            }
         }
     }
 }


### PR DESCRIPTION
makes the VolumeOSD only show when `mycroft.volume.display` is emitted

it was reusing the .get.response message which had side effects such as showing VolumeOSD in every utterance

`mycroft.volume.display` should now be emitted explicitly, usually by the volume skill

deprecates the following messages, moving to the standard bus api
- `mycroft.volume.get.sliding.panel`
- `mycroft.volume.get.sliding.panel.response`
- `mycroft.volume.set.gui`

companion PR needed in PHAL alsa plugin + https://openvoiceos.github.io/message_spec/PHAL_alsa/